### PR TITLE
fix fifteenPuzzle generates only unsolvable boards

### DIFF
--- a/applets/fifteenPuzzle/package/contents/ui/FifteenPuzzle.qml
+++ b/applets/fifteenPuzzle/package/contents/ui/FifteenPuzzle.qml
@@ -93,12 +93,12 @@ Item {
 
         // we have a solveable board if:
         // size is odd:  there are an even number of inversions
-        // size is even: the number of inversions is odd if and only if
+        // size is even: the number of inversions is even if and only if
         //               the blank tile is on an odd row from the bottom-
         var sizeMod2 = Math.floor(boardSize % 2);
         var inversionsMod2 = Math.floor(inversions % 2);
         var solveable = (sizeMod2 == 1 && inversionsMod2 == 0) ||
-                         (sizeMod2 == 0 && inversionsMod2 == 0) == (Math.floor((boardSize - blankRow) % 2) == 1);
+                         (sizeMod2 == 0 && inversionsMod2 == 0) == (Math.floor((boardSize - blankRow) % 2) == 0);
         if (!solveable) {
             // make the grid solveable by swapping two adjacent pieces around
             var pieceA = 0;


### PR DESCRIPTION
If the grid width is even, and the blank is on an odd row counting from the bottom (last, third-last, fifth-last etc) then the number of inversions in a solvable situation must be even. See following link https://www.cs.bham.ac.uk/~mdr/teaching/modules04/java2/TilesSolvability.html