### PR TITLE
Fix ksysguard not starting on plasmoid click

### DIFF
--- a/applets/systemloadviewer/package/contents/ui/SystemLoadViewer.qml
+++ b/applets/systemloadviewer/package/contents/ui/SystemLoadViewer.qml
@@ -125,10 +125,16 @@ Item {
     Kio.KRun { id: kRun }
 
     // We need to get the full path to KSysguard to be able to run it
+    property var ksysguardUrl
+    
     PlasmaCore.DataSource {
         id: apps
         engine: "apps"
         connectedSources: ["org.kde.ksysguard.desktop"]
+        onNewData: {
+            if(sourceName == "org.kde.ksysguard.desktop")
+                ksysguardUrl = data.entryPath
+        }
     }
 
     PlasmaCore.DataSource {
@@ -386,7 +392,7 @@ Item {
             anchors.fill: parent
             hoverEnabled: true
             onClicked: {
-                kRun.openUrl(apps.data["org.kde.ksysguard.desktop"].entryPath)
+                kRun.openUrl(ksysguardUrl)
             }
         }
     }
@@ -422,7 +428,7 @@ Item {
             anchors.fill: parent
             hoverEnabled: true
             onClicked: {
-                kRun.openUrl(apps.data["org.kde.ksysguard.desktop"].entryPath)
+                kRun.openUrl(ksysguardUrl)
             }
         }
     }


### PR DESCRIPTION
After plasmoid has been running for some time, clicking it would produce error:
_"file:///usr/share/plasma/plasmoids/org.kde.plasma.systemloadviewer/contents/ui/SystemLoadViewer.qml:389: TypeError: Cannot read property 'entryPath' of undefined"_
instead of launching ksysguard.

Ksysguard now starts without delay after click, since url doesn't have to be looked up.
