### PR TITLE
Added an extra fuzzytime setting - Hobbit Time

### DIFF
--- a/applets/fuzzy-clock/package/contents/ui/FuzzyClock.qml
+++ b/applets/fuzzy-clock/package/contents/ui/FuzzyClock.qml
@@ -186,6 +186,11 @@ Item {
           i18n("Five to one") ]
     ]
 
+    readonly property var hobbitTime: [
+        i18n("Sleep"), i18n("Breakfast"), i18n("Second Breakfast"), i18n("Elevenses"),
+        i18n("Lunch"), i18n("Afternoon tea"), i18n("Dinner"), i18n("Supper")
+    ]
+
     readonly property var dayTime: [
         i18n("Night"), i18n("Early morning"), i18n("Morning"), i18n("Almost noon"),
         i18n("Noon"), i18n("Afternoon"), i18n("Evening"), i18n("Late evening")
@@ -233,6 +238,8 @@ Item {
 
             return hourNames[Math.floor(realHour)][sector]
         } else if (main.fuzzyness == 3) {
+            return hobbitTime[Math.floor(hours / 3)]
+        } else if (main.fuzzyness == 4) {
             return dayTime[Math.floor(hours / 3)]
         } else {
             var dow = d.getDay()

--- a/applets/fuzzy-clock/package/contents/ui/configAppearance.qml
+++ b/applets/fuzzy-clock/package/contents/ui/configAppearance.qml
@@ -65,7 +65,7 @@ Item {
                     id: fuzzyness
                     QtLayouts.Layout.fillWidth: true
                     minimumValue: 1
-                    maximumValue: 4
+                    maximumValue: 5
                     stepSize: 1
                     tickmarksEnabled: true
                 }


### PR DESCRIPTION
Not 100% serious, a fun little extension for Hobbits.

If you wanted to eat like a hobbit you would have these meals:
Breakfast - 7am.
Second breakfast - 9 am.
Elevenses - 11 am.
Lunch - 1 pm.
Afternoon tea - 3pm.
Dinner - 6 pm.
Supper - 9 pm.