### PR TITLE
Changed hexadecimal system to decimal.

### DIFF
--- a/applets/binary-clock/package/contents/ui/BinaryClock.qml
+++ b/applets/binary-clock/package/contents/ui/BinaryClock.qml
@@ -83,13 +83,13 @@ Item {
     DotColumn {
         x:displayLeft
         y:displayTop
-        val:hours
-        startbit:4
+        val:hours/10
+        startbit:0
     }
     DotColumn {
         x:displayLeft+(dotSize+units.smallSpacing)
         y:displayTop
-        val:hours
+        val:hours%10
         startbit:0
     }
 
@@ -98,13 +98,13 @@ Item {
     DotColumn {
         x:displayLeft+(dotSize+units.smallSpacing)*2
         y:displayTop
-        val:minutes
-        startbit:4
+        val:minutes/10
+        startbit:0
     }
     DotColumn {
         x:displayLeft+(dotSize+units.smallSpacing)*3
         y:displayTop
-        val:minutes
+        val:minutes%10
         startbit:0
     }
 
@@ -112,15 +112,15 @@ Item {
     DotColumn {
         x:displayLeft+(dotSize+units.smallSpacing)*4
         y:displayTop
-        val:seconds
-        startbit:4
+        val:seconds/10
+        startbit:0
         visible:showSeconds
     }
 
     DotColumn {
         x:displayLeft+(dotSize+units.smallSpacing)*5
         y:displayTop
-        val:seconds
+        val:seconds%10
         startbit:0
         visible:showSeconds
     }


### PR DESCRIPTION
Hours, minutes and seconds are in hexadecimal system. I don't know if it was intended or just temporarily ported to Plasma5 that way but it's not an expected behavior from my perspective.
![binary clock](https://user-images.githubusercontent.com/24587734/36067709-291ba316-0ec3-11e8-9ace-a51ae1dd7fd9.png)
(the hour was 00:19 in my digital clock when I made the screenshot)